### PR TITLE
feat(xds): add a workflow to print PR context

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -1,0 +1,23 @@
+name: "test-pr"
+on:
+  push:
+    branches: ["master", "release-*", "!*-merge-master"]
+    tags: ["*"]
+  pull_request:
+    branches: ["master", "release-*"]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "Output context variables"
+        run: |
+          echo 'github.sha: ${{ github.sha }}'
+          echo 'github.ref_name: ${{ github.ref_name }}'
+          echo 'github.event.pull_request.head.sha: ${{ github.event.pull_request.head.sha }}'
+          echo 'github.event.pull_request.id: ${{ github.event.pull_request.id }}'
+          echo 'github.event.pull_request.number: ${{ github.event.pull_request.number }}'
+          echo 'github.event.pull_request.merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}'
+          echo 'github.event_name: ${{ github.event_name }}'


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
